### PR TITLE
RetainKeys, Recycling Connections, Buffered Sends, More BufferedTimer stats

### DIFF
--- a/event/absolute.go
+++ b/event/absolute.go
@@ -18,6 +18,11 @@ func (e *Absolute) Update(e2 Event) error {
 	return nil
 }
 
+//Reset the value
+func (e *Absolute) Reset() {
+	e.Values = []int64{}
+}
+
 // Payload returns the aggregated value for this event
 func (e Absolute) Payload() interface{} {
 	return e.Values

--- a/event/fabsolute.go
+++ b/event/fabsolute.go
@@ -18,6 +18,11 @@ func (e *FAbsolute) Update(e2 Event) error {
 	return nil
 }
 
+//Reset the value
+func (e *FAbsolute) Reset() {
+	e.Values = []float64{}
+}
+
 // Payload returns the aggregated value for this event
 func (e FAbsolute) Payload() interface{} {
 	return e.Values

--- a/event/fgauge.go
+++ b/event/fgauge.go
@@ -19,6 +19,10 @@ func (e *FGauge) Update(e2 Event) error {
 	return nil
 }
 
+//Reset the value GAUGES TO NOT RESET
+func (e *FGauge) Reset() {
+}
+
 // Payload returns the aggregated value for this event
 func (e FGauge) Payload() interface{} {
 	return e.Value

--- a/event/fgaugedelta.go
+++ b/event/fgaugedelta.go
@@ -24,6 +24,11 @@ func (e FGaugeDelta) Payload() interface{} {
 	return e.Value
 }
 
+//Reset the value
+func (e *FGaugeDelta) Reset() {
+	e.Value = 0.0
+}
+
 // Stats returns an array of StatsD events as they travel over UDP
 func (e FGaugeDelta) Stats() []string {
 	if e.Value < 0 {

--- a/event/gauge.go
+++ b/event/gauge.go
@@ -24,6 +24,11 @@ func (e Gauge) Payload() interface{} {
 	return e.Value
 }
 
+//Reset the value GAUGES TO NOT RESET
+func (e *Gauge) Reset() {
+
+}
+
 // Stats returns an array of StatsD events as they travel over UDP
 func (e Gauge) Stats() []string {
 	if e.Value < 0 {

--- a/event/gaugedelta.go
+++ b/event/gaugedelta.go
@@ -24,6 +24,11 @@ func (e GaugeDelta) Payload() interface{} {
 	return e.Value
 }
 
+//Reset the value
+func (e *GaugeDelta) Reset() {
+	e.Value = 0
+}
+
 // Stats returns an array of StatsD events as they travel over UDP
 func (e GaugeDelta) Stats() []string {
 	if e.Value < 0 {

--- a/event/increment.go
+++ b/event/increment.go
@@ -17,6 +17,11 @@ func (e *Increment) Update(e2 Event) error {
 	return nil
 }
 
+//Reset the value
+func (e *Increment) Reset() {
+	e.Value = 0
+}
+
 // Payload returns the aggregated value for this event
 func (e Increment) Payload() interface{} {
 	return e.Value

--- a/event/interface.go
+++ b/event/interface.go
@@ -24,4 +24,5 @@ type Event interface {
 	String() string
 	Key() string
 	SetKey(string)
+	Reset()
 }

--- a/event/precisiontiming.go
+++ b/event/precisiontiming.go
@@ -32,6 +32,14 @@ func (e *PrecisionTiming) Update(e2 Event) error {
 	return nil
 }
 
+//Reset the value
+func (e *PrecisionTiming) Reset() {
+	e.Value = 0
+	e.Count = 1
+	e.Min = time.Duration(0)
+	e.Max = time.Duration(0)
+}
+
 // Payload returns the aggregated value for this event
 func (e PrecisionTiming) Payload() interface{} {
 	return e
@@ -40,9 +48,10 @@ func (e PrecisionTiming) Payload() interface{} {
 // Stats returns an array of StatsD events as they travel over UDP
 func (e PrecisionTiming) Stats() []string {
 	return []string{
+		fmt.Sprintf("%s.count:%d|a", e.Name, int64(e.Count)),
 		fmt.Sprintf("%s.avg:%.6f|a", e.Name, float64(int64(e.Value)/e.Count)), // make sure e.Count != 0
-		fmt.Sprintf("%s.min:%.6f|a", e.Name, e.Min),
-		fmt.Sprintf("%s.max:%.6f|a", e.Name, e.Max),
+		fmt.Sprintf("%s.min:%.6f|a", e.Name, float64(e.Min)),
+		fmt.Sprintf("%s.max:%.6f|a", e.Name, float64(e.Max)),
 	}
 }
 

--- a/event/total.go
+++ b/event/total.go
@@ -17,6 +17,11 @@ func (e *Total) Update(e2 Event) error {
 	return nil
 }
 
+//Reset the value
+func (e *Total) Reset() {
+	e.Value = 0
+}
+
 // Payload returns the aggregated value for this event
 func (e Total) Payload() interface{} {
 	return e.Value

--- a/noopclient.go
+++ b/noopclient.go
@@ -1,0 +1,20 @@
+package statsd
+
+
+//impliment a "noop" statsd in case there is no statsd
+type StatsdNoop struct{}
+
+func (s StatsdNoop) CreateSocket() error                                    { return nil }
+func (s StatsdNoop) Close() error                                           { return nil }
+func (s StatsdNoop) Incr(stat string, count int64) error                    { return nil }
+func (s StatsdNoop) Decr(stat string, count int64) error                    { return nil }
+func (s StatsdNoop) Timing(stat string, count int64) error                  { return nil }
+func (s StatsdNoop) PrecisionTiming(stat string, delta time.Duration) error { return nil }
+func (s StatsdNoop) Gauge(stat string, value int64) error                   { return nil }
+func (s StatsdNoop) GaugeDelta(stat string, value int64) error              { return nil }
+func (s StatsdNoop) Absolute(stat string, value int64) error                { return nil }
+func (s StatsdNoop) Total(stat string, value int64) error                   { return nil }
+func (s StatsdNoop) FGauge(stat string, value float64) error                { return nil }
+func (s StatsdNoop) FGaugeDelta(stat string, value float64) error           { return nil }
+func (s StatsdNoop) FAbsolute(stat string, value float64) error             { return nil }
+


### PR DESCRIPTION
1) more stats to timers
2) RetainKeys options for Buffer client to keep send stats even if they
are 0
3) send stats in may lines (not one connection per line)
4) Add "Reset" to events (to deal with retain keys)
5) Add a NoOp client for easy switching when there is no statsd in your
land
6) ReCycleConnection for buffered client to close connections after
sending (in order to pick up and new IPs)