### PR TITLE
make collector exit on close request

### DIFF
--- a/bufferedclient.go
+++ b/bufferedclient.go
@@ -150,7 +150,7 @@ func (sb *StatsdBuffer) collector() {
 		case c := <-sb.closeChannel:
 			sb.Logger.Println("Asked to terminate. Flushing stats before returning.")
 			c.reply <- sb.flush()
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
the break was only breaking from the select, and was entering the for loop again