### PR TITLE
Add standard (global) statsd client

### DIFF
--- a/std.go
+++ b/std.go
@@ -1,0 +1,49 @@
+package statsd
+
+import "sync"
+
+var std Statsd
+var mu sync.Mutex
+
+func Init() {
+	std = &NoopClient{}
+}
+
+// Configure creates a global StatsD client.
+// TODO: Use a buffered client instead!
+func Configure(host string, prefix string) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	client := NewStatsdClient(host, prefix)
+	err := client.CreateSocket()
+	if err != nil {
+		return err
+	}
+
+	std = client
+	return nil
+}
+
+// These functions write to the global StatsD client if one has been configured,
+// otherwise do nothing.
+
+func Incr(stat string, count int64) error {
+	return std.Incr(stat, count)
+}
+
+func Decr(stat string, count int64) error {
+	return std.Decr(stat, count)
+}
+
+func Timing(stat string, delta int64) error {
+	return std.Timing(stat, delta)
+}
+
+func Absolute(stat string, value int64) error {
+	return std.Absolute(stat, value)
+}
+
+func Total(stat string, value int64) error {
+	return std.Total(stat, value)
+}

--- a/std_test.go
+++ b/std_test.go
@@ -1,0 +1,1 @@
+package statsd


### PR DESCRIPTION
The stdlib `log` package provides a useful "standard" logger, which can be used globally without passing a logger object around. This PR does the same thing for statsd, except the default behavior is no-op until `statsd.Configure` is called. What do you think? (This is just a quick proposal for now, so please don't merge it yet.)