### PR TITLE
Loss of Precision on PrecisionTiming on BufferedClient

### DIFF
--- a/bufferedclient.go
+++ b/bufferedclient.go
@@ -70,7 +70,7 @@ func (sb *StatsdBuffer) Timing(stat string, delta int64) error {
 // PrecisionTiming - Track a duration event
 // the time delta has to be a duration
 func (sb *StatsdBuffer) PrecisionTiming(stat string, delta time.Duration) error {
-	sb.eventChannel <- event.NewPrecisionTiming(stat, time.Duration(float64(delta)/float64(time.Millisecond)))
+	sb.eventChannel <- event.NewPrecisionTiming(stat, delta)
 	return nil
 }
 


### PR DESCRIPTION
Looks like PrecisionTiming should still be passing delta, not calculating milliseconds at this point.  The conversion appears to occur later.  Since time.Duration is an int64, there is loss of precision here, so the value is always 0 if the delta is less than a millisecond.  I tested this and I am seeing the correct values for milliseconds on payload to Statsd.