### PR TITLE
Issue #30 : bufferedclient generates less udp traffic

### DIFF
--- a/bufferedclient.go
+++ b/bufferedclient.go
@@ -188,15 +188,11 @@ func (sb *StatsdBuffer) flush() (err error) {
 		sb.Logger.Println("Error establishing UDP connection for sending statsd events:", err)
 		return err
 	}
-	for k, v := range sb.events {
-		err := sb.statsd.SendEvent(v)
-		if nil != err {
-			sb.Logger.Println(err)
-			continue
-		}
-		//sb.Logger.Println("Sent", v.String())
-		delete(sb.events, k)
-	}
 
+	if err := sb.statsd.SendEvents(sb.events); err != nil {
+		sb.Logger.Println(err)
+		return err
+	}
+	sb.events = make(map[string]event.Event)
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -11,10 +11,15 @@ import (
 	"github.com/quipo/statsd/event"
 )
 
-// MaxStatsSize is the number of bytes to send at one go through the udp socket.
-// SendEvents will try to send as many events as it can in one go based on this
-// parameter.
-var MaxStatsSize int = 16 * 1024
+// UDPPayloadSize is the number of bytes to send at one go through the udp socket.
+// SendEvents will try to pack as many events into one udp packet.
+// Change this value as per network capabilities
+// For example to change to 16KB
+//  import "github.com/quipo/statsd"
+//  func init() {
+//   statsd.UDPPayloadSize = 16 * 1024
+//  }
+var UDPPayloadSize int = 512
 
 // Logger interface compatible with log.Logger
 type Logger interface {
@@ -200,7 +205,7 @@ func (c *StatsdClient) SendEvent(e event.Event) error {
 }
 
 // SendEvents - Sends stats from all the event objects.
-// Tries to bundle many together into one fmt.Fprintf based on MaxStatsSize.
+// Tries to bundle many together into one fmt.Fprintf based on UDPPayloadSize.
 func (c *StatsdClient) SendEvents(events map[string]event.Event) error {
 	if c.conn == nil {
 		return fmt.Errorf("cannot send stats, not connected to StatsD server")
@@ -215,7 +220,7 @@ func (c *StatsdClient) SendEvents(events map[string]event.Event) error {
 			stat = fmt.Sprintf("%s%s", c.prefix, strings.Replace(stat, "%HOST%", Hostname, 1))
 			_n := n + len(stat) + 1
 
-			if _n <= MaxStatsSize {
+			if _n <= UDPPayloadSize {
 				n = _n
 				stats = append(stats, stat)
 				continue


### PR DESCRIPTION
Introduced package level variable MaxStatsSize which is 16kb by default.
BufferedClient flushes to SendEvents rather than SendEvent.
SendEvents tries to pack as many stats as it can until MaxStatsSize is
reached, separated by \n.
This leads to decreased udp traffic.

Previously without this fix, my processes were generating udp traffic at around 40k packets per second.
With this change it has gone down to around 2k packets per second.
Since one can fine tune more, I made the MaxStatsSize variable, so that it can be changed based on users network capabilities.