### PR TITLE
Added CreateTCPSocket to interface and the NoopClient.

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -5,6 +5,7 @@ import "time"
 // Statsd is an interface to a StatsD client (buffered/unbuffered)
 type Statsd interface {
 	CreateSocket() error
+	CreateTCPSocket() error
 	Close() error
 	Incr(stat string, count int64) error
 	Decr(stat string, count int64) error

--- a/noopclient.go
+++ b/noopclient.go
@@ -14,6 +14,11 @@ func (s NoopClient) CreateSocket() error {
 	return nil
 }
 
+// CreateTCPSocket does nothing
+func (s NoopClient) CreateTCPSocket() error {
+	return nil
+}
+
 // Close does nothing
 func (s NoopClient) Close() error {
 	return nil


### PR DESCRIPTION
## What does this PR solve?
CreateTCPSocket function introduced in #24 is not in the Statsd interface and in the NoopClient. 

Run the following code: 
```go
var client statsd.Statsd
client = statsd.NewStatsdClient("localhost:8125", "testprefix")
err := client.CreateTCPSocket()
if err != nil {
    log.Fatalf("Error occured setting up statsd. Error: %q\n", err.Error())
}
```
Result from my use case:
```bash
$ go build
./monitoring.go:48: statsdclient.CreateTCPSocket undefined (type statsd.Statsd has no field or method CreateTCPSocket)
```

## Solution
Added `CreateTCPSocket` to Statsd interface and an empty noop function to `NoopClient`.

## How to test
Run the code snippet before and after the fix.

## Risk
None, this is a backwards compatible change, not affecting other parts of the code.