### PR TITLE
BufferedClient: Do not create a new UDP socket on every flush

### DIFF
--- a/bufferedclient.go
+++ b/bufferedclient.go
@@ -207,11 +207,6 @@ func (sb *StatsdBuffer) flush() (err error) {
 	if n == 0 {
 		return nil
 	}
-	err = sb.statsd.CreateSocket()
-	if nil != err {
-		sb.Logger.Println("Error establishing UDP connection for sending statsd events:", err)
-		return err
-	}
 	if err := sb.statsd.SendEvents(sb.events); err != nil {
 		sb.Logger.Println(err)
 		return err

--- a/bufferedclient_test.go
+++ b/bufferedclient_test.go
@@ -39,7 +39,7 @@ func TestBufferedTotal(t *testing.T) {
 	hostname, err := os.Hostname()
 	expected["zz."+hostname] = 1
 
-	go doListenUDP(t, ln, ch, len(s))
+	go doListenUDP(t, ln, ch, 1)
 
 	err = buffered.CreateSocket()
 	if nil != err {

--- a/client_test.go
+++ b/client_test.go
@@ -146,8 +146,8 @@ func doListenUDP(t *testing.T, conn *net.UDPConn, ch chan string, n int) {
 }
 
 func doListenTCP(t *testing.T, conn net.Listener, ch chan string, n int) {
+	client, err := conn.Accept()
 	for {
-		client, err := conn.Accept()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -155,11 +155,16 @@ func doListenTCP(t *testing.T, conn net.Listener, ch chan string, n int) {
 		buf := make([]byte, 1024)
 		c, err := client.Read(buf)
 		if err != nil {
+			if err.Error() == "EOF" {
+				return
+			}
 			t.Fatal(err)
 		}
 
 		for _, s := range bytes.Split(buf[:c], []byte{'\n'}) {
-			ch <- string(s)
+			if len(s) > 0 {
+				ch <- string(s)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This enables the BufferedClient to operate over TCP.

Also fixed tests.