### PR TITLE
Provide mock statsd client with convenience recorders.

### DIFF
--- a/mock/mockableclient.go
+++ b/mock/mockableclient.go
@@ -1,0 +1,357 @@
+package mock
+
+//
+// A mockable client allowing arbitrary functions to be called statsd.Statsd methods.
+//
+// This is particularly helpful in unit test scenarios where it is desired to simulate calls
+// without actually writing to a network or filesystem.
+//
+// A default implementation is provided that records all calls and can be used for verification
+// in unit tests.
+//
+// The default implementations of these methods are no-ops, so without any further configuration,
+// &MockStatsdClient{} is equivalent to statsd.NoopClient. But utility methods are also provided that
+// allow recording calls for the purposes of verification during unit testing.
+//
+
+import (
+	"sync"
+	"time"
+
+	"github.com/quipo/statsd/event"
+)
+
+type statelessStatsdFunction func() error
+type intMetricStatsdFunction func(string, int64) error
+type floatMetricStatsdFunction func(string, float64) error
+type durationMetricStatsdFunction func(string, time.Duration) error
+type eventsStatsdFunction func(events map[string]event.Event) error
+
+// MockStatsdClient at its simplest provides a layer of indirection so that
+// arbitrary functions can be used as the targets of calls to the Statsd interface
+//
+// In its basic state, it will act like a noop client.
+//
+// There are also helper functions that will set functions for specific
+// calls to record those events to caller-provided slices.
+// This is particularly helpful for unit testing that needs to verify
+// that certain metrics have been recorded by the system under test
+
+type MockStatsdClient struct {
+	CreateSocketFn    statelessStatsdFunction
+	CreateTCPSocketFn statelessStatsdFunction
+	CloseFn           statelessStatsdFunction
+	IncrFn            intMetricStatsdFunction
+	DecrFn            intMetricStatsdFunction
+	TimingFn          intMetricStatsdFunction
+	PrecisionTimingFn durationMetricStatsdFunction
+	GaugeFn           intMetricStatsdFunction
+	GaugeDeltaFn      intMetricStatsdFunction
+	AbsoluteFn        intMetricStatsdFunction
+	TotalFn           intMetricStatsdFunction
+
+	FGaugeFn      floatMetricStatsdFunction
+	FGaugeDeltaFn floatMetricStatsdFunction
+	FAbsoluteFn   floatMetricStatsdFunction
+
+	SendEventsFn eventsStatsdFunction
+}
+
+// Implement statsd interface
+
+func (msc *MockStatsdClient) CreateSocket() error {
+	if msc.CreateSocketFn == nil {
+		return nil
+	}
+	return msc.CreateSocketFn()
+}
+
+func (msc *MockStatsdClient) CreateTCPSocket() error {
+	if msc.CreateTCPSocketFn == nil {
+		return nil
+	}
+	return msc.CreateTCPSocketFn()
+}
+
+func (msc *MockStatsdClient) Close() error {
+	if msc.CloseFn == nil {
+		return nil
+	}
+	return msc.CloseFn()
+}
+
+func (msc *MockStatsdClient) Incr(stat string, count int64) error {
+	if msc.IncrFn == nil {
+		return nil
+	}
+	return msc.IncrFn(stat, count)
+}
+
+func (msc *MockStatsdClient) Decr(stat string, count int64) error {
+	if msc.DecrFn == nil {
+		return nil
+	}
+	return msc.DecrFn(stat, count)
+}
+
+func (msc *MockStatsdClient) Timing(stat string, delta int64) error {
+	if msc.TimingFn == nil {
+		return nil
+	}
+	return msc.TimingFn(stat, delta)
+}
+
+func (msc *MockStatsdClient) PrecisionTiming(stat string, delta time.Duration) error {
+	if msc.PrecisionTimingFn == nil {
+		return nil
+	}
+	return msc.PrecisionTimingFn(stat, delta)
+}
+
+func (msc *MockStatsdClient) Gauge(stat string, value int64) error {
+	if msc.GaugeFn == nil {
+		return nil
+	}
+	return msc.GaugeFn(stat, value)
+}
+
+func (msc *MockStatsdClient) GaugeDelta(stat string, value int64) error {
+	if msc.GaugeDeltaFn == nil {
+		return nil
+	}
+	return msc.GaugeDeltaFn(stat, value)
+}
+
+func (msc *MockStatsdClient) Absolute(stat string, value int64) error {
+	if msc.AbsoluteFn == nil {
+		return nil
+	}
+	return msc.AbsoluteFn(stat, value)
+}
+
+func (msc *MockStatsdClient) Total(stat string, value int64) error {
+	if msc.TotalFn == nil {
+		return nil
+	}
+	return msc.TotalFn(stat, value)
+}
+
+func (msc *MockStatsdClient) FGauge(stat string, value float64) error {
+	if msc.FGaugeFn == nil {
+		return nil
+	}
+	return msc.FGaugeFn(stat, value)
+}
+
+func (msc *MockStatsdClient) FGaugeDelta(stat string, value float64) error {
+	if msc.FGaugeDeltaFn == nil {
+		return nil
+	}
+	return msc.FGaugeDeltaFn(stat, value)
+}
+
+func (msc *MockStatsdClient) FAbsolute(stat string, value float64) error {
+	if msc.FAbsoluteFn == nil {
+		return nil
+	}
+	return msc.FAbsoluteFn(stat, value)
+}
+
+func (msc *MockStatsdClient) SendEvents(events map[string]event.Event) error {
+	if msc.SendEventsFn == nil {
+		return nil
+	}
+	return msc.SendEventsFn(events)
+}
+
+// Mocking helpers that record seen events for verification during unit testing
+
+type Int64Event struct {
+	MetricName string
+	EventValue int64
+}
+
+type Float64Event struct {
+	MetricName string
+	EventValue float64
+}
+
+type DurationEvent struct {
+	MetricName string
+	EventValue time.Duration
+}
+
+// UnvaluedEvents are useful for recording things like calls to Close() or CreateSocket()
+type UnvaluedEvent struct {
+}
+
+// Fluent-style constructors for recording events to caller-provided slices
+// This means that during unit tests, one can do something like
+//
+// incrEvents := []statsd.Int64Event
+// decrEvents := []statsd.Int64Event
+// statsdClient = &MockStatsdClient{}.RecordIncrEventsTo(&incrEvents).RecordDecrEventsTo(&decrEvents)
+// ... Execute code under test that records metrics
+// ... Verify that incrEvents and decrEvents have seen the expected events
+
+func (msc *MockStatsdClient) RecordCreateSocketEventsTo(createSocketEvents *[]UnvaluedEvent) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.CreateSocketFn = func() error {
+		recordUnvaluedEvent(eventLock, createSocketEvents)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordCreateTCPSocketEventsTo(createTcpSocketEvents *[]UnvaluedEvent) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.CreateTCPSocketFn = func() error {
+		recordUnvaluedEvent(eventLock, createTcpSocketEvents)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordCloseEventsTo(closeEvents *[]UnvaluedEvent) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.CloseFn = func() error {
+		recordUnvaluedEvent(eventLock, closeEvents)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordIncrEventsTo(incrEvents *[]Int64Event) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.IncrFn = func(metricName string, eventValue int64) error {
+		recordInt64Event(eventLock, incrEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordDecrEventsTo(decrEvents *[]Int64Event) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.DecrFn = func(metricName string, eventValue int64) error {
+		recordInt64Event(eventLock, decrEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordTimingEventsTo(timingEvents *[]Int64Event) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.TimingFn = func(metricName string, eventValue int64) error {
+		recordInt64Event(eventLock, timingEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordPrecisionTimingEventsTo(timingEvents *[]DurationEvent) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.PrecisionTimingFn = func(metricName string, eventValue time.Duration) error {
+		recordDurationEvent(eventLock, timingEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordGaugeEventsTo(gaugeEvents *[]Int64Event) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.GaugeFn = func(metricName string, eventValue int64) error {
+		recordInt64Event(eventLock, gaugeEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordGaugeDeltaEventsTo(gaugeDeltaEvents *[]Int64Event) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.GaugeDeltaFn = func(metricName string, eventValue int64) error {
+		recordInt64Event(eventLock, gaugeDeltaEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordAbsoluteEventsTo(absoluteEvents *[]Int64Event) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.AbsoluteFn = func(metricName string, eventValue int64) error {
+		recordInt64Event(eventLock, absoluteEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordTotalEventsTo(totalEvents *[]Int64Event) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.TotalFn = func(metricName string, eventValue int64) error {
+		recordInt64Event(eventLock, totalEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordFGaugeEventsTo(fgaugeEvents *[]Float64Event) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.FGaugeFn = func(metricName string, eventValue float64) error {
+		recordFloat64Event(eventLock, fgaugeEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordFGaugeDeltaEventsTo(fgaugeDeltaEvents *[]Float64Event) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.FGaugeDeltaFn = func(metricName string, eventValue float64) error {
+		recordFloat64Event(eventLock, fgaugeDeltaEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func (msc *MockStatsdClient) RecordFAbsoluteEventsTo(fabsoluteEvents *[]Float64Event) *MockStatsdClient {
+	eventLock := &sync.Mutex{}
+	msc.FAbsoluteFn = func(metricName string, eventValue float64) error {
+		recordFloat64Event(eventLock, fabsoluteEvents, metricName, eventValue)
+		return nil
+	}
+	return msc
+}
+
+func recordDurationEvent(eventLock sync.Locker, events *[]DurationEvent, metricName string, eventValue time.Duration) {
+	newEvent := DurationEvent{
+		MetricName: metricName,
+		EventValue: eventValue,
+	}
+	eventLock.Lock()
+	defer eventLock.Unlock()
+	*events = append(*events, newEvent)
+}
+
+func recordFloat64Event(eventLock sync.Locker, events *[]Float64Event, metricName string, eventValue float64) {
+	newEvent := Float64Event{
+		MetricName: metricName,
+		EventValue: eventValue,
+	}
+	eventLock.Lock()
+	defer eventLock.Unlock()
+	*events = append(*events, newEvent)
+}
+
+func recordInt64Event(eventLock sync.Locker, events *[]Int64Event, metricName string, eventValue int64) {
+	newEvent := Int64Event{
+		MetricName: metricName,
+		EventValue: eventValue,
+	}
+	eventLock.Lock()
+	defer eventLock.Unlock()
+	*events = append(*events, newEvent)
+}
+
+func recordUnvaluedEvent(eventLock sync.Locker, events *[]UnvaluedEvent) {
+	eventLock.Lock()
+	defer eventLock.Unlock()
+	*events = append(*events, UnvaluedEvent{})
+}

--- a/mock/mockableclient_test.go
+++ b/mock/mockableclient_test.go
@@ -1,0 +1,341 @@
+package mock
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/quipo/statsd/event"
+)
+
+func TestNoopBehavior(t *testing.T) {
+	mockClient := MockStatsdClient{}
+	err := mockClient.CreateSocket()
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.CreateTCPSocket()
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.Close()
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.Incr("incr", 1)
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.Decr("decr", 2)
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.Timing("timing", 3)
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.PrecisionTiming("precisionTiming", 4)
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.Gauge("gauge", 5)
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.GaugeDelta("gaugeDelta", 6)
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.Absolute("absolute", 7)
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.Total("total", 8)
+	if err != nil {
+		t.Fail()
+	}
+
+	err = mockClient.FGauge("fgauge", 10.0)
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.FGaugeDelta("fgaugeDelta", 11.0)
+	if err != nil {
+		t.Fail()
+	}
+	err = mockClient.FAbsolute("fabsolute", 12.0)
+	if err != nil {
+		t.Fail()
+	}
+
+	err = mockClient.SendEvents(make(map[string]event.Event))
+	if err != nil {
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordCreateSocketEventsTo(t *testing.T) {
+	var createSocketEvents []UnvaluedEvent
+	mockClient := (&MockStatsdClient{}).RecordCreateSocketEventsTo(&createSocketEvents)
+	err := mockClient.CreateSocket()
+	if err != nil {
+		t.Logf("Got non-nil err from mock CreateSocket")
+		t.Fail()
+	}
+	expectedEvents := []UnvaluedEvent{UnvaluedEvent{}}
+	if !reflect.DeepEqual(createSocketEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, createSocketEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordCreateTCPSocketEventsTo(t *testing.T) {
+	var createTCPSocketEvents []UnvaluedEvent
+	mockClient := (&MockStatsdClient{}).RecordCreateTCPSocketEventsTo(&createTCPSocketEvents)
+	err := mockClient.CreateTCPSocket()
+	if err != nil {
+		t.Logf("Got non-nil err from mock CreateTCPSocket")
+		t.Fail()
+	}
+	expectedEvents := []UnvaluedEvent{UnvaluedEvent{}}
+	if !reflect.DeepEqual(createTCPSocketEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, createTCPSocketEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordCloseEventsTo(t *testing.T) {
+	var closeEvents []UnvaluedEvent
+	mockClient := (&MockStatsdClient{}).RecordCloseEventsTo(&closeEvents)
+	err := mockClient.Close()
+	if err != nil {
+		t.Logf("Got non-nil err from mock Close")
+		t.Fail()
+	}
+	expectedEvents := []UnvaluedEvent{UnvaluedEvent{}}
+	if !reflect.DeepEqual(closeEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, closeEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordIncrEventsTo(t *testing.T) {
+	var incrEvents []Int64Event
+	mockClient := (&MockStatsdClient{}).RecordIncrEventsTo(&incrEvents)
+	err := mockClient.Incr("incr", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock Incr")
+		t.Fail()
+	}
+	expectedEvents := []Int64Event{Int64Event{MetricName: "incr", EventValue: 1}}
+	if !reflect.DeepEqual(incrEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, incrEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_Decr(t *testing.T) {
+	var decrEvents []Int64Event
+	mockClient := (&MockStatsdClient{}).RecordDecrEventsTo(&decrEvents)
+	err := mockClient.Decr("decr", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock Decr")
+		t.Fail()
+	}
+	expectedEvents := []Int64Event{Int64Event{MetricName: "decr", EventValue: 1}}
+	if !reflect.DeepEqual(decrEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, decrEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_Timing(t *testing.T) {
+	var timingEvents []Int64Event
+	mockClient := (&MockStatsdClient{}).RecordIncrEventsTo(&timingEvents)
+	err := mockClient.Incr("timing", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock Timing")
+		t.Fail()
+	}
+	expectedEvents := []Int64Event{Int64Event{MetricName: "timing", EventValue: 1}}
+	if !reflect.DeepEqual(timingEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, timingEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordPrecisionTimingEventsTo(t *testing.T) {
+	var durationEvents []DurationEvent
+	mockClient := (&MockStatsdClient{}).RecordPrecisionTimingEventsTo(&durationEvents)
+	err := mockClient.PrecisionTiming("precisionTiming", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock PrecisionTiming")
+		t.Fail()
+	}
+	expectedEvents := []DurationEvent{DurationEvent{MetricName: "precisionTiming", EventValue: 1}}
+	if !reflect.DeepEqual(durationEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, durationEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordGaugeEventsTo(t *testing.T) {
+	var gaugeEvents []Int64Event
+	mockClient := (&MockStatsdClient{}).RecordGaugeEventsTo(&gaugeEvents)
+	err := mockClient.Gauge("gauge", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock Gauge")
+		t.Fail()
+	}
+	expectedEvents := []Int64Event{Int64Event{MetricName: "gauge", EventValue: 1}}
+	if !reflect.DeepEqual(gaugeEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, gaugeEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordFGaugeDeltaEventsTo(t *testing.T) {
+	var gaugeDeltaEvents []Int64Event
+	mockClient := (&MockStatsdClient{}).RecordGaugeDeltaEventsTo(&gaugeDeltaEvents)
+	err := mockClient.GaugeDelta("gaugeDelta", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock GaugeDelta")
+		t.Fail()
+	}
+	expectedEvents := []Int64Event{Int64Event{MetricName: "gaugeDelta", EventValue: 1}}
+	if !reflect.DeepEqual(gaugeDeltaEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, gaugeDeltaEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordAbsoluteEventsTo(t *testing.T) {
+	var absoluteEvents []Int64Event
+	mockClient := (&MockStatsdClient{}).RecordAbsoluteEventsTo(&absoluteEvents)
+	err := mockClient.Absolute("absolute", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock Absolute")
+		t.Fail()
+	}
+	expectedEvents := []Int64Event{Int64Event{MetricName: "absolute", EventValue: 1}}
+	if !reflect.DeepEqual(absoluteEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, absoluteEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordTotalEventsTo(t *testing.T) {
+	var totalEvents []Int64Event
+	mockClient := (&MockStatsdClient{}).RecordTotalEventsTo(&totalEvents)
+	err := mockClient.Total("total", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock Total")
+		t.Fail()
+	}
+	expectedEvents := []Int64Event{Int64Event{MetricName: "total", EventValue: 1}}
+	if !reflect.DeepEqual(totalEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, totalEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordFGaugeEventsTo(t *testing.T) {
+	var fgaugeEvents []Float64Event
+	mockClient := (&MockStatsdClient{}).RecordFGaugeEventsTo(&fgaugeEvents)
+	err := mockClient.FGauge("fgauge", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock FGauge")
+		t.Fail()
+	}
+	expectedEvents := []Float64Event{Float64Event{MetricName: "fgauge", EventValue: 1}}
+	if !reflect.DeepEqual(fgaugeEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, fgaugeEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordFGaugeDeltaEventsTo2(t *testing.T) {
+	var fgaugeDeltaEvents []Float64Event
+	mockClient := (&MockStatsdClient{}).RecordFGaugeDeltaEventsTo(&fgaugeDeltaEvents)
+	err := mockClient.FGaugeDelta("fgaugeDelta", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock FGaugeDelta")
+		t.Fail()
+	}
+	expectedEvents := []Float64Event{Float64Event{MetricName: "fgaugeDelta", EventValue: 1}}
+	if !reflect.DeepEqual(fgaugeDeltaEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, fgaugeDeltaEvents)
+		t.Fail()
+	}
+}
+
+func TestMockStatsdClient_RecordFAbsoluteEventsTo(t *testing.T) {
+	var fabsoluteEvents []Float64Event
+	mockClient := (&MockStatsdClient{}).RecordFAbsoluteEventsTo(&fabsoluteEvents)
+	err := mockClient.FAbsolute("fabsolute", 1)
+	if err != nil {
+		t.Logf("Got non-nil err from mock FAbsolute")
+		t.Fail()
+	}
+	expectedEvents := []Float64Event{Float64Event{MetricName: "fabsolute", EventValue: 1}}
+	if !reflect.DeepEqual(fabsoluteEvents, expectedEvents) {
+		t.Logf("Expected %s, saw %s", expectedEvents, fabsoluteEvents)
+		t.Fail()
+	}
+}
+
+//func TestRecordingBuilders(t *testing.T) {
+//	var createTcpSocketEvents []UnvaluedEvent
+//	var closeEvents []UnvaluedEvent
+//	var incrEvents []Int64Event
+//	var decrEvents []Int64Event
+//	var timingEvents []Int64Event
+//	var precidionTimingEvents []DurationEvent
+//	var gaugeEvents []Int64Event
+//	var gaugeDeltaEvents []Int64Event
+//	var absoluteEvents []Int64Event
+//	var totalEvents []Int64Event
+//	var fgaugeEvents []Float64Event
+//	var fgaugeDeltaEvents []Float64Event
+//	var fabsoluteEvents []Float64Event
+//
+//	mockClient := &MockStatsdClient{}.
+//		RecordCreateSocketEventsTo(&createSocketEvents).
+//		RecordCreateTCPSocketEventsTo(&createTcpSocketEvents).
+//		RecordCloseEventsTo(&closeEvents).
+//		RecordIncrEventsTo(&incrEvents).
+//		RecordDecrEventsTo(&decrEvents).
+//		RecordTimingEventsTo(&timingEvents).
+//		RecordPrecisionTimingEventsTo(&precidionTimingEvents).
+//		RecordGaugeEventsTo(&gaugeEvents).
+//		RecordGaugeDeltaEventsTo(&gaugeDeltaEvents).
+//		RecordAbsoluteEventsTo(&absoluteEvents).
+//		RecordTotalEventsTo(&totalEvents).
+//		RecordFGaugeEventsTo(&fgaugeEvents).
+//		RecordFGaugeDeltaEventsTo(&fgaugeDeltaEvents).
+//		RecordFAbsoluteEventsTo(&fabsoluteEvents)
+//
+//	err := mockClient.CreateSocket()
+//	if err != nil {
+//		t.Fail()
+//	}
+//	err = mockClient.CreateTCPSocket()
+//	if err != nil {
+//		t.Fail()
+//	}
+//	err = mockClient.Close()
+//	if err != nil {
+//		t.Fail()
+//	}
+//	err = mockClient.Incr("incr", 1)
+//	if err != nil {
+//		t.Fail()
+//	}
+//	err = mockClient.Decr("decr", 1)
+//	if err != nil {
+//		t.Fail()
+//	}
+//	err = mockClient.Timing("timing", 1)
+//	if err != nil {
+//		t.Fail()
+//	}
+//}


### PR DESCRIPTION
It is often useful when unit testing instrumented code
to verify that the expected instrumenation is being recorded
in addition to verifying the correctness and performance of
that code. This commit adds a mock client that enables that
form of verification without having to spin up a UDP listener.

The basic approach here is to provide a level of indirection
between the statsd.Statsd interface and the methods use to
implement that interface. That allows arbitrary behavior to
be invoked in response to different methods invoked on the
MockStatsdClient. If no such method or methods are provided,
calling a method on the MockStatsdClient will just be no-op.

That alone would allow for test cases to provide their own
mock functions. But the common use case for testing is to record
the events sent to the mock client and verify that the
instrumentation methods one expected to be invoked were invoked
with the proper arguments. To support this common use case,
a series of flient builders are provided for MockStatsdClient
that will allow a client to provide a slice to be used to record
events. The test file provides examples of using this fluent builder.