### PR TITLE
Use scalable and efficient sampler

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -1,0 +1,54 @@
+package statsd
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// SyncSampler is a sampler designed for non-contended cases.
+type SyncSampler struct {
+	mu  sync.Mutex
+	rng *rand.Rand
+}
+
+// PoolSampler is a sampler designed for contended cases.
+type PoolSampler struct {
+	pool sync.Pool
+}
+
+var DefaultSampler = NewPoolSampler()
+
+func NewSyncSampler() *SyncSampler {
+	return &SyncSampler{
+		rng: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+func NewPoolSampler() *PoolSampler {
+	return &PoolSampler{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return rand.New(rand.NewSource(time.Now().UnixNano()))
+			},
+		},
+	}
+}
+
+func (s *SyncSampler) ShouldFire(rate float32) bool {
+	s.mu.Lock()
+	shouldFire := roll(s.rng, rate)
+	s.mu.Unlock()
+	return shouldFire
+}
+
+func (s *PoolSampler) ShouldFire(rate float32) bool {
+	rng := s.pool.Get().(*rand.Rand)
+	shouldFire := roll(rng, rate)
+	s.pool.Put(rng)
+	return shouldFire
+}
+
+func roll(rng *rand.Rand, sampleRate float32) bool {
+	return rng.Float32() <= sampleRate
+}


### PR DESCRIPTION
The sampler may now be passed to `statsd.StatsdClient` to redefine sampling
behaviour. The default sampler uses pool of random number generators in
order to be efficient and scalable. The other provided sampler `statsd.SyncSampler`
is a little bit more efficient in non-contended cases but doesn't scale.