### PR TITLE
Periodic reconnect to avoid stale UDP connections

### DIFF
--- a/bufferedclient.go
+++ b/bufferedclient.go
@@ -22,7 +22,7 @@ type StatsdBuffer struct {
 	eventChannel  chan event.Event
 	events        map[string]event.Event
 	closeChannel  chan closeRequest
-	Logger        Logger
+	Logger        *log.Logger
 	Verbose       bool
 }
 

--- a/bufferedclient_test.go
+++ b/bufferedclient_test.go
@@ -161,7 +161,7 @@ func TestBufferedInt64(t *testing.T) {
 			defer ln.Close()
 
 			t.Log("Starting new UDP listener at", udpAddr.String())
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			client := NewStatsdClient(udpAddr.String(), prefix)
 			buffered := NewStatsdBuffer(time.Millisecond*20, client)
@@ -169,7 +169,7 @@ func TestBufferedInt64(t *testing.T) {
 			ch := make(chan string)
 
 			go doListenUDP(t, ln, ch, len(tc.expected))
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			err = buffered.CreateSocket()
 			if nil != err {
@@ -234,7 +234,7 @@ func TestBufferedInt64(t *testing.T) {
 				t.Errorf("did not receive all metrics: Expected: %T %v, Actual: %T %v ", tc.expected, tc.expected, actual, actual)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }
@@ -300,7 +300,7 @@ func TestBufferedFloat64(t *testing.T) {
 			defer ln.Close()
 
 			t.Log("Starting new UDP listener at", udpAddr.String())
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			client := NewStatsdClient(udpAddr.String(), prefix)
 			buffered := NewStatsdBuffer(time.Millisecond*20, client)
@@ -308,7 +308,7 @@ func TestBufferedFloat64(t *testing.T) {
 			ch := make(chan string)
 
 			go doListenUDP(t, ln, ch, len(tc.expected))
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			err = buffered.CreateSocket()
 			if nil != err {
@@ -366,7 +366,7 @@ func TestBufferedFloat64(t *testing.T) {
 				t.Errorf("did not receive all metrics: Expected: \n%T %v, \nActual: \n%T %v ", tc.expected, tc.expected, actual, actual)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }
@@ -413,7 +413,7 @@ func TestBufferedAbsolute(t *testing.T) {
 			defer ln.Close()
 
 			t.Log("Starting new UDP listener at", udpAddr.String())
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			client := NewStatsdClient(udpAddr.String(), prefix)
 			buffered := NewStatsdBuffer(time.Millisecond*20, client)
@@ -421,7 +421,7 @@ func TestBufferedAbsolute(t *testing.T) {
 			ch := make(chan string)
 
 			go doListenUDP(t, ln, ch, len(tc.expected))
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			err = buffered.CreateSocket()
 			if nil != err {
@@ -473,7 +473,7 @@ func TestBufferedAbsolute(t *testing.T) {
 				t.Errorf("did not receive all metrics: \nExpected: \n%T %v, \nActual: \n%T %v ", tc.expected, tc.expected, actual, actual)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }
@@ -520,7 +520,7 @@ func TestBufferedFAbsolute(t *testing.T) {
 			defer ln.Close()
 
 			t.Log("Starting new UDP listener at", udpAddr.String())
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			client := NewStatsdClient(udpAddr.String(), prefix)
 			buffered := NewStatsdBuffer(time.Millisecond*20, client)
@@ -528,7 +528,7 @@ func TestBufferedFAbsolute(t *testing.T) {
 			ch := make(chan string)
 
 			go doListenUDP(t, ln, ch, len(tc.expected))
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			err = buffered.CreateSocket()
 			if nil != err {
@@ -580,7 +580,7 @@ func TestBufferedFAbsolute(t *testing.T) {
 				t.Errorf("did not receive all metrics: \nExpected: \n%T %v, \nActual: \n%T %v ", tc.expected, tc.expected, actual, actual)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }

--- a/client.go
+++ b/client.go
@@ -54,27 +54,56 @@ const (
 
 // StatsdClient is a client library to send events to StatsD
 type StatsdClient struct {
-	conn     net.Conn
-	addr     string
-	prefix   string
-	sockType socketType
-	Logger   Logger
+	conn             net.Conn
+	addr             string
+	prefix           string
+	sockType         socketType
+	Logger           Logger
+	reconnect_ticker *time.Ticker
 }
 
 // NewStatsdClient - Factory
 func NewStatsdClient(addr string, prefix string) *StatsdClient {
 	// allow %HOST% in the prefix string
 	prefix = strings.Replace(prefix, "%HOST%", Hostname, 1)
-	return &StatsdClient{
-		addr:   addr,
-		prefix: prefix,
-		Logger: log.New(os.Stdout, "[StatsdClient] ", log.Ldate|log.Ltime),
+	client := &StatsdClient{
+		addr:             addr,
+		prefix:           prefix,
+		Logger:           log.New(os.Stdout, "[StatsdClient] ", log.Ldate|log.Ltime),
+		reconnect_ticker: time.NewTicker(30 * time.Second),
 	}
+
+	go func() {
+		for range client.reconnect_ticker.C {
+			err := client.Reconnect()
+			if err != nil {
+				fmt.Println(err)
+			}
+		}
+	}()
+	return client
 }
 
 // String returns the StatsD server address
 func (c *StatsdClient) String() string {
 	return c.addr
+}
+
+func (c *StatsdClient) Reconnect() error {
+	var err error
+	if c.sockType == "udp" {
+		fmt.Println("creating new udp")
+		err = c.CreateSocket()
+	} else if c.sockType == "tcp" {
+		fmt.Println("creating new tcp")
+		err = c.CreateTCPSocket()
+	} else if c.sockType == "" {
+		return fmt.Errorf("No socket created, cannot identify connection type")
+	}
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // CreateSocket creates a UDP connection to a StatsD server

--- a/client.go
+++ b/client.go
@@ -59,6 +59,7 @@ type StatsdClient struct {
 	prefix           string
 	sockType         socketType
 	Logger           Logger
+	reconnect        bool
 	reconnect_ticker *time.Ticker
 }
 
@@ -70,14 +71,17 @@ func NewStatsdClient(addr string, prefix string) *StatsdClient {
 		addr:             addr,
 		prefix:           prefix,
 		Logger:           log.New(os.Stdout, "[StatsdClient] ", log.Ldate|log.Ltime),
+		reconnect:        false,
 		reconnect_ticker: time.NewTicker(30 * time.Second),
 	}
 
 	go func() {
 		for range client.reconnect_ticker.C {
-			err := client.Reconnect()
-			if err != nil {
-				fmt.Println(err)
+			if client.reconnect {
+				err := client.Reconnect()
+				if err != nil {
+					fmt.Println(err)
+				}
 			}
 		}
 	}()

--- a/client.go
+++ b/client.go
@@ -75,7 +75,7 @@ func NewStatsdClient(addr string, prefix string) *StatsdClient {
 			if client.reconnect {
 				err := client.Reconnect()
 				if err != nil {
-					fmt.Println(err)
+					client.Logger.Println(err)
 				}
 			}
 		}
@@ -91,10 +91,10 @@ func (c *StatsdClient) String() string {
 func (c *StatsdClient) Reconnect() error {
 	var err error
 	if c.sockType == "udp" {
-		fmt.Println("creating new udp")
+		c.Logger.Printf("Reconnecing to udp server at %s", c.String())
 		err = c.CreateSocket()
 	} else if c.sockType == "tcp" {
-		fmt.Println("creating new tcp")
+		c.Logger.Printf("Reconnecing to tcp server at %s", c.String())
 		err = c.CreateTCPSocket()
 	} else if c.sockType == "" {
 		return fmt.Errorf("No socket created, cannot identify connection type")
@@ -322,7 +322,7 @@ func (c *StatsdClient) SendEvent(e event.Event) error {
 		return errNotConnected
 	}
 	for _, stat := range e.Stats() {
-		//fmt.Printf("SENDING EVENT %s%s\n", c.prefix, strings.Replace(stat, "%HOST%", Hostname, 1))
+		//c.Logger.Printf("SENDING EVENT %s%s\n", c.prefix, strings.Replace(stat, "%HOST%", Hostname, 1))
 		_, err := fmt.Fprintf(c.conn, "%s%s", c.prefix, strings.Replace(stat, "%HOST%", Hostname, 1))
 		if nil != err {
 			return err

--- a/client.go
+++ b/client.go
@@ -13,11 +13,6 @@ import (
 	"github.com/quipo/statsd/event"
 )
 
-// Logger interface compatible with log.Logger
-type Logger interface {
-	Println(v ...interface{})
-}
-
 // UDPPayloadSize is the number of bytes to send at one go through the udp socket.
 // SendEvents will try to pack as many events into one udp packet.
 // Change this value as per network capabilities
@@ -58,7 +53,7 @@ type StatsdClient struct {
 	addr             string
 	prefix           string
 	sockType         socketType
-	Logger           Logger
+	Logger           *log.Logger
 	reconnect        bool
 	reconnect_ticker *time.Ticker
 }

--- a/client_test.go
+++ b/client_test.go
@@ -615,6 +615,44 @@ func newLocalListenerUDP(t *testing.T) (*net.UDPConn, *net.UDPAddr) {
 	return ln, udpAddr
 }
 
+func TestReconnecting(t *testing.T) {
+	ln, udpAddr := newLocalListenerUDP(t)
+	defer ln.Close()
+
+	prefix := "test."
+
+	client := NewStatsdClient(udpAddr.String(), prefix)
+	client.reconnect_ticker = time.NewTicker(10 * time.Millisecond)
+
+	ch := make(chan string, 0)
+
+	s := map[string]int64{
+		"a:b:c": 5,
+		"d:e:f": 2,
+	}
+
+	go doListenUDP(t, ln, ch, len(s))
+
+	client.CreateSocket()
+	client.Close()
+
+	time.Sleep(15 * time.Millisecond)
+	for k, v := range s {
+		fmt.Println("sent", k, v)
+		client.Total(k, v)
+	}
+
+	timeout := time.After(30 * time.Millisecond)
+	for i := len(s); i > 0; i-- {
+		select {
+		case x := <-ch:
+			fmt.Println("received", x)
+		case <-timeout:
+			t.Fatal("Timed out")
+		}
+	}
+}
+
 func doListenUDP(t *testing.T, conn *net.UDPConn, ch chan string, n int) {
 	var wg sync.WaitGroup
 	wg.Add(n)

--- a/client_test.go
+++ b/client_test.go
@@ -638,16 +638,16 @@ func TestReconnecting(t *testing.T) {
 	client.Close()
 
 	time.Sleep(15 * time.Millisecond)
+	timeout := time.After(5 * time.Millisecond)
+
 	for k, v := range s {
-		fmt.Println("sent", k, v)
+		t.Log("sent", k, v)
 		client.Total(k, v)
 	}
 
-	timeout := time.After(30 * time.Millisecond)
 	for i := len(s); i > 0; i-- {
 		select {
-		case x := <-ch:
-			fmt.Println("received", x)
+		case <-ch:
 		case <-timeout:
 			t.Fatal("Timed out")
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -622,6 +622,7 @@ func TestReconnecting(t *testing.T) {
 	prefix := "test."
 
 	client := NewStatsdClient(udpAddr.String(), prefix)
+	client.reconnect = true
 	client.reconnect_ticker = time.NewTicker(10 * time.Millisecond)
 
 	ch := make(chan string, 0)

--- a/client_test.go
+++ b/client_test.go
@@ -615,6 +615,10 @@ func newLocalListenerUDP(t *testing.T) (*net.UDPConn, *net.UDPAddr) {
 	return ln, udpAddr
 }
 
+func Teardown(c *StatsdClient) {
+	c.reconnect = false
+}
+
 func TestReconnecting(t *testing.T) {
 	ln, udpAddr := newLocalListenerUDP(t)
 	defer ln.Close()
@@ -624,6 +628,8 @@ func TestReconnecting(t *testing.T) {
 	client := NewStatsdClient(udpAddr.String(), prefix)
 	client.reconnect = true
 	client.reconnect_ticker = time.NewTicker(10 * time.Millisecond)
+
+	defer Teardown(client)
 
 	ch := make(chan string, 0)
 
@@ -652,7 +658,6 @@ func TestReconnecting(t *testing.T) {
 			t.Fatal("Timed out")
 		}
 	}
-	client.reconnect = false
 }
 
 func doListenUDP(t *testing.T, conn *net.UDPConn, ch chan string, n int) {

--- a/client_test.go
+++ b/client_test.go
@@ -175,14 +175,14 @@ func TestClientInt64(t *testing.T) {
 			defer ln.Close()
 
 			t.Log("Starting new UDP listener at", udpAddr.String())
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			client := NewStatsdClient(udpAddr.String(), prefix)
 
 			ch := make(chan string)
 
 			go doListenUDP(t, ln, ch, len(tc.expected))
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			err = client.CreateSocket()
 			if nil != err {
@@ -247,7 +247,7 @@ func TestClientInt64(t *testing.T) {
 				t.Errorf("did not receive all metrics: \nExpected: \n%T %v, \nActual: \n%T %v ", tc.expected, tc.expected, actual, actual)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }
@@ -316,14 +316,14 @@ func TestClientFloat64(t *testing.T) {
 			defer ln.Close()
 
 			t.Log("Starting new UDP listener at", udpAddr.String())
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			client := NewStatsdClient(udpAddr.String(), prefix)
 
 			ch := make(chan string)
 
 			go doListenUDP(t, ln, ch, len(tc.expected))
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			err = client.CreateSocket()
 			if nil != err {
@@ -382,7 +382,7 @@ func TestClientFloat64(t *testing.T) {
 				t.Errorf("did not receive all metrics: Expected: \n%T %v, \nActual: \n%T %v ", tc.expected, tc.expected, actual, actual)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }
@@ -429,14 +429,14 @@ func TestClientAbsolute(t *testing.T) {
 			defer ln.Close()
 
 			t.Log("Starting new UDP listener at", udpAddr.String())
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			client := NewStatsdClient(udpAddr.String(), prefix)
 
 			ch := make(chan string)
 
 			go doListenUDP(t, ln, ch, len(tc.expected))
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			err = client.CreateSocket()
 			if nil != err {
@@ -488,7 +488,7 @@ func TestClientAbsolute(t *testing.T) {
 				t.Errorf("did not receive all metrics: \nExpected: \n%T %v, \nActual: \n%T %v ", tc.expected, tc.expected, actual, actual)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }
@@ -535,14 +535,14 @@ func TestClientFAbsolute(t *testing.T) {
 			defer ln.Close()
 
 			t.Log("Starting new UDP listener at", udpAddr.String())
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			client := NewStatsdClient(udpAddr.String(), prefix)
 
 			ch := make(chan string)
 
 			go doListenUDP(t, ln, ch, len(tc.expected))
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 
 			err = client.CreateSocket()
 			if nil != err {
@@ -594,7 +594,7 @@ func TestClientFAbsolute(t *testing.T) {
 				t.Errorf("did not receive all metrics: \nExpected: \n%T %v, \nActual: \n%T %v ", tc.expected, tc.expected, actual, actual)
 			}
 
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }
@@ -726,7 +726,7 @@ func TestTCP(t *testing.T) {
 	defer ln.Close()
 
 	t.Log("Starting new TCP listener at", addr)
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	prefix := "myproject."
 	client := NewStatsdClient(addr, prefix)
@@ -766,10 +766,10 @@ func TestTCP(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	go doListenTCP(t, ln, ch, len(s))
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	actual := make(map[string]int64)
 

--- a/client_test.go
+++ b/client_test.go
@@ -652,6 +652,7 @@ func TestReconnecting(t *testing.T) {
 			t.Fatal("Timed out")
 		}
 	}
+	client.reconnect = false
 }
 
 func doListenUDP(t *testing.T, conn *net.UDPConn, ch chan string, n int) {

--- a/stdoutclient.go
+++ b/stdoutclient.go
@@ -14,7 +14,7 @@ import (
 type StdoutClient struct {
 	FD     *os.File
 	prefix string
-	Logger Logger
+	Logger *log.Logger
 }
 
 // NewStdoutClient - Factory


### PR DESCRIPTION
**What?**
Allows the client to periodically reconnect to the server.
```
client := NewStatsdClient(udpAddr.String(), prefix)
client.reconnect = true
```

**Why?**
We are using this library within Kubernetes and when our statsd servers get recreated (within Kubernetes) a connection to an old service endpoint results in metrics being emitted via UDP and going nowhere. We believe this is due to conntrack keeping the route open because there is at least one client that is connected to it (the app that implements this library).